### PR TITLE
Upgrade to Django 1.8.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8
+Django==1.8.18
 Pillow==2.8.1
 django-debug-toolbar==1.3.0
 django-wysiwyg==0.7.0


### PR DESCRIPTION
Since matfystutor.dk was upgraded to Django 1.8 in [May 2015] there has been 18 bugfix/security releases, most recently on [April 4, 2017].

It should be safe to upgrade Django on pulerau using the command `pip install -U django\<1.8.99` (when in the venv) which installs the newest 1.8.x-release. The `requirements.txt` file should specify which version is being used on the site.

[May 2015]: https://github.com/matfystutor/web/commit/442aca2474
[April 4, 2017]: https://docs.djangoproject.com/en/1.8/releases/1.8.18/