### PR TITLE
Tutorbog crossword puzzle solution validator

### DIFF
--- a/mftutor/settings/base.py
+++ b/mftutor/settings/base.py
@@ -190,7 +190,8 @@ INSTALLED_APPS = (
     'mftutor.dump',
     'mftutor.rusclass',
     'mftutor.signup',
-    'mftutor.groups'
+    'mftutor.groups',
+    'mftutor.tutorbog',
 )
 
 # A sample logging configuration. The only tangible logging

--- a/mftutor/settings/base.py
+++ b/mftutor/settings/base.py
@@ -169,6 +169,8 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
+    'constance',
+    'constance.backends.database',
 
     'django_wysiwyg',
     'debug_toolbar',
@@ -275,3 +277,10 @@ GF_GROUPS = ('best', 'koor', 'webfar', 'oekonomi', 'gris')
 
 THUMBNAIL_KVSTORE = 'sorl.thumbnail.kvstores.dbm_kvstore.KVStore'
 THUMBNAIL_DBM_FILE = '/home/mftutor/web/thumbnails/thumbnail_kvstore'
+
+CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'
+
+CONSTANCE_CONFIG = {
+    'TUTORBOG_SECRET': ('', 'Svaret til krydsorden i tutorbogen'),
+    'TUTORBOG_SURVEY_URL': ('', 'URL til tutorbog surveyen'),
+}

--- a/mftutor/tutorbog/admin.py
+++ b/mftutor/tutorbog/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/mftutor/tutorbog/admin.py
+++ b/mftutor/tutorbog/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/mftutor/tutorbog/apps.py
+++ b/mftutor/tutorbog/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class TutorbogConfig(AppConfig):
+    name = 'tutorbog'

--- a/mftutor/tutorbog/models.py
+++ b/mftutor/tutorbog/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/mftutor/tutorbog/models.py
+++ b/mftutor/tutorbog/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/mftutor/tutorbog/tests.py
+++ b/mftutor/tutorbog/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/mftutor/tutorbog/tests.py
+++ b/mftutor/tutorbog/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/mftutor/tutorbog/urls.py
+++ b/mftutor/tutorbog/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from mftutor.tutorbog.views import secret_view
+
+urlpatterns = [
+    path('<secret>/', secret_view),
+]

--- a/mftutor/tutorbog/views.py
+++ b/mftutor/tutorbog/views.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.models import User
+from django.shortcuts import redirect
+from django.http import HttpResponseNotFound
+
+
+USERNAME = 'tutorbog_krydsord'
+
+
+def secret_view(request, secret):
+    user = User.objects.get(username=USERNAME)
+    if user.check_password(secret):
+        # Should be replaced by either:
+        # * A redirect to the real survey, or
+        # * A survey implemented on the website
+        return redirect('https://example.org/')
+    else:
+        # Should probably be prettier
+        return HttpResponseNotFound('Forkert løsning, prøv igen!', content_type='text/plain; charset=utf-8')

--- a/mftutor/tutorbog/views.py
+++ b/mftutor/tutorbog/views.py
@@ -1,18 +1,17 @@
-from django.contrib.auth.models import User
 from django.shortcuts import redirect
 from django.http import HttpResponseNotFound
-
-
-USERNAME = 'tutorbog_krydsord'
+from constance import config
 
 
 def secret_view(request, secret):
-    user = User.objects.get(username=USERNAME)
-    if user.check_password(secret):
-        # Should be replaced by either:
-        # * A redirect to the real survey, or
-        # * A survey implemented on the website
-        return redirect('https://example.org/')
+    if not config.TUTORBOG_SECRET:
+        raise RuntimeError('No tutorbog secret configured')
+
+    if not config.TUTORBOG_SURVEY_URL:
+        raise RuntimeError('No tutorbog survey url configured')
+
+    if secret == config.TUTORBOG_SECRET:
+        return redirect(config.TUTORBOG_SURVEY_URL)
     else:
         # Should probably be prettier
         return HttpResponseNotFound('Forkert løsning, prøv igen!', content_type='text/plain; charset=utf-8')

--- a/mftutor/urls.py
+++ b/mftutor/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('dump/', include('mftutor.dump.urls')),
     path('browser/', include('mftutor.browser.urls')),
     path('tutorhold/', include('mftutor.rusclass.urls')),
+    path('tutorbog/', include('mftutor.tutorbog.urls')),
 ]
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-wysiwyg==0.7.0
 sqlparse==0.2.4
 sorl-thumbnail==12.3
 django-su==0.8.0
+django-constance[database]==2.4.0


### PR DESCRIPTION
Lige nu "linker" tutorbogen til `http://bit.do/14123` (hvor `14123` er bogstaverne fra løsningen til kryds-og-tværsen). Det er så meningen at denne skal redirecte videre til en Google Forms eller lignende for at få noget statistik over hvor mange der har læst tutorbogen.

Jeg tænker det ville give mening at linke til vores egen hjemmeside i stedet for, som så selv redirecter til den rigtige Google Forms.

Jeg har lavet en groft udkast til hvordan det kunne gøres. Grunden til at jeg tjekker om løsningen matcher `tutorbog_krydsord` brugerens password, er at vi så ikke har løsningen til at stå i kildekoden.
Desuden gør det det også nemmere at opdatere løsningen, hvis kryds-og-tværsen bliver ændret.

For at bruge det skal der således oprettes en bruger `tutorbog_krydsord` med et password. Når man så besøger `/tutorbog/<password>` så bliver man redirected, hvis man har givet det rigtige password.