### PR TITLE
Fix switching between table and list view for tutors

### DIFF
--- a/mftutor/templates/tutors.html
+++ b/mftutor/templates/tutors.html
@@ -23,10 +23,10 @@ Vælg gruppe:
 {% endif %}
 <p>Vis som:
 <label>
-<input onclick="document.getElementsByClassName('tutorcontainer')[0].className = 'tutorcontainer tutorlist'"
+<input onclick="Array.from(document.getElementsByClassName('tutorcontainer')).forEach(c => {c.className = 'tutorcontainer tutortable';})"
 name="tutorcontainer" type="radio" value="tutorlist" checked="checked"> Liste</label>
 <label>
-<input onclick="document.getElementsByClassName('tutorcontainer')[0].className = 'tutorcontainer tutortable'"
+<input onclick="Array.from(document.getElementsByClassName('tutorcontainer')).forEach(c => {c.className = 'tutorcontainer tutortable';})"
 name="tutorcontainer" type="radio" value="tutortable"> Tabel</label>
 </p>
 <p>


### PR DESCRIPTION
There is a bug in the conversion between list and table view on https://matfystutor.dk/tutors/ since a separate container for the tutorFORM has been added, so that view (index 0) is the only one being converted. I fixed it by looping through all containers in the query list and changing the view for each container.