### PR TITLE
Added Rus2Tur Sponsor Edition Guide 2024

### DIFF
--- a/mftutor/page/templates/rus2tur.html
+++ b/mftutor/page/templates/rus2tur.html
@@ -2,16 +2,22 @@
 {% block title %}Rus2tur{% endblock %}
 
 {% block content %}
-<h1>Rus2tur</h1>
+<h1>Rus2Tur</h1>
 
 <p>
-Rus2ture er hytteture i forlængelse af rusturene, og afholdes således af rushold og eventuelt
+Rus2Ture er hytteture i forlængelse af rusturene, og afholdes således af rushold og eventuelt
 deres tutorer.
 </p>
 
 <p>
-Der kan findes en guide til afvikling af Rus2tur (og selvfølgelig dem derefter)
+Der kan findes en guide til afvikling af Rus2Tur (og selvfølgelig dem derefter)
 <a href="https://matfystutor.dk/upload/docs/2022/udgivelser/Rus2TurGuide2022.pdf">her</a>.
+</p>
+
+<p>
+Mat/Fys-Tutorforeningen må ikke tage imod sponsorater, men arrangerer man selv en Rus2Tur, 
+må man gerne finde eventuelle samarbejdspartnere, og i den forbindelse kan man læse 
+<q>Rus2Tur-Sponsor Edition</q>-guiden <a href="https://matfystutor.dk/upload/docs/2022/udgivelser/Rus2TurSponsorEdition2024.pdf" alt="rus2tur sponsor guide">her</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Guiden skal lægges op på serveren, med fil stien: ".../upload/docs/2022/udgivelser/Rus2TurSponsorEdition2024.pdf".
[Rus2TurSponsorEdition2024.pdf](https://github.com/user-attachments/files/16313389/Rus2TurSponsorEdition2024.pdf)
